### PR TITLE
Make extension TYPO3 9.5 compatible

### DIFF
--- a/Classes/Controller/EinsatzController.php
+++ b/Classes/Controller/EinsatzController.php
@@ -12,8 +12,11 @@ class EinsatzController extends ActionController
      */
     protected $einsatzRepository;
 
-    // Moderne Dependency Injection (ab TYPO3 10+)
-    public function __construct(EinsatzRepository $einsatzRepository)
+
+    /**
+     * Inject the repository (compatible with TYPO3 9.5)
+     */
+    public function injectEinsatzRepository(EinsatzRepository $einsatzRepository): void
     {
         $this->einsatzRepository = $einsatzRepository;
     }

--- a/Classes/Domain/Model/Car.php
+++ b/Classes/Domain/Model/Car.php
@@ -6,9 +6,20 @@ use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 
 class Car extends AbstractEntity
 {
-    protected string $title = '';
-    protected string $link = '';
-    protected ?FileReference $image = null;
+    /**
+     * @var string
+     */
+    protected $title = '';
+
+    /**
+     * @var string
+     */
+    protected $link = '';
+
+    /**
+     * @var FileReference|null
+     */
+    protected $image = null;
 
     public function getTitle(): string
     {

--- a/Classes/Domain/Model/Einsatz.php
+++ b/Classes/Domain/Model/Einsatz.php
@@ -10,21 +10,64 @@ use Vendor\Firefighter\Domain\Model\Type;
 
 class Einsatz extends AbstractEntity
 {
-    protected string $title = '';
-    protected string $location = '';
-    protected string $description = '';
-    protected string $shortDescription = '';
-    protected ?\DateTime $datefrom = null;
-    protected ?\DateTime $dateto = null;
-    protected string $geoCoords = '';
-    protected string $number = '';
-    protected int $mens = 0;
+    /**
+     * @var string
+     */
+    protected $title = '';
+
+    /**
+     * @var string
+     */
+    protected $location = '';
+
+    /**
+     * @var string
+     */
+    protected $description = '';
+
+    /**
+     * @var string
+     */
+    protected $shortDescription = '';
+
+    /**
+     * @var \DateTime|null
+     */
+    protected $datefrom = null;
+
+    /**
+     * @var \DateTime|null
+     */
+    protected $dateto = null;
+
+    /**
+     * @var string
+     */
+    protected $geoCoords = '';
+
+    /**
+     * @var string
+     */
+    protected $number = '';
+
+    /**
+     * @var int
+     */
+    protected $mens = 0;
+
+    /**
+     * @var string
+     */
+    protected $stations = '';
 
     /**
      * Fahrzeuge (MM-Beziehung)
      * @var ObjectStorage<Car>
      */
-    protected ObjectStorage $cars;
+    /**
+     * @var ObjectStorage<Car>
+     */
+    protected $cars;
 
     /**
      * Einsatztyp (Single Relation)
@@ -73,6 +116,9 @@ class Einsatz extends AbstractEntity
 
     public function getMens(): int { return $this->mens; }
     public function setMens(int $mens): void { $this->mens = $mens; }
+
+    public function getStations(): string { return $this->stations; }
+    public function setStations(string $stations): void { $this->stations = $stations; }
 
     // === Cars (MM Relation) ===
     public function getCars(): ObjectStorage { return $this->cars; }

--- a/Classes/Domain/Model/Type.php
+++ b/Classes/Domain/Model/Type.php
@@ -6,9 +6,20 @@ use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 
 class Type extends AbstractEntity
 {
-    protected string $title = '';
-    protected ?FileReference $image = null;
-    protected string $link = '';
+    /**
+     * @var string
+     */
+    protected $title = '';
+
+    /**
+     * @var FileReference|null
+     */
+    protected $image = null;
+
+    /**
+     * @var string
+     */
+    protected $link = '';
 
     public function getTitle(): string
     {

--- a/Classes/Updates/RenameEinsatzTableWizard.php
+++ b/Classes/Updates/RenameEinsatzTableWizard.php
@@ -7,7 +7,10 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 
 class RenameTablesWizard implements UpgradeWizardInterface
 {
-    protected array $tablesToRename = [
+    /**
+     * @var array
+     */
+    protected $tablesToRename = [
         'tx_firefighter_einsatz' => 'tx_firefighter_domain_model_einsatz',
         'tx_firefighter_type' => 'tx_firefighter_domain_model_type',
         'tx_firefighter_car' => 'tx_firefighter_domain_model_car',

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "typo3-cms-extension",
   "description": "Feuerwehr Einsatzliste für TYPO3",
   "require": {
-    "typo3/cms-core": "^8.5 || ^12.0"
+    "typo3/cms-core": "^9.5 || ^10.4 || ^11.5 || ^12.4"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.5.0-12.9.99',
+            'typo3' => '9.5.0-12.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
## Summary
- update composer constraints for TYPO3 >= 9.5
- require TYPO3 >= 9.5 in ext_emconf
- switch to property injection for controller
- drop PHP 7.4 typed properties from domain models and update update wizard
- add missing stations field to model

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684349a8bbd083329fcae6c9961fc1b2